### PR TITLE
Make Editor default

### DIFF
--- a/asciidoctor-editor-plugin/plugin.xml
+++ b/asciidoctor-editor-plugin/plugin.xml
@@ -34,6 +34,7 @@
             icon="icons/asciidoctor-editor.png"
             contributorClass="org.eclipse.ui.texteditor.BasicTextEditorActionContributor"
             class="de.jcup.asciidoctoreditor.AsciiDoctorEditor"
+	    default="true"  
             id="asciidoctoreditor.editors.AsciiDoctorEditor">
       </editor>
    </extension>


### PR DESCRIPTION
Make Editor default, so when plugin is installed, it should redefine association

Currently user still needs to associate with .adoc files (when Mylyn is installed)