### PR TITLE
Improves header color for the dark theme

### DIFF
--- a/asciidoctor-editor-plugin/css/dark.css
+++ b/asciidoctor-editor-plugin/css/dark.css
@@ -5,7 +5,7 @@ IEclipsePreferences#de-jcup-asciidoctoreditor:de-jcup-asciidoctoreditor { /* pse
 		'colorTextBold=85,255,255'
 		'colorTextBlocks=49,98,98'
 		'colorNormalText=192,192,192'
-		'colorHeadlines=186,57,37'
+		'colorHeadlines=86,156,214'
 		'colorComments=63,127,95',
 		'colorIncludeKeywords=128,128,0'
 		'colorCommands=0,128,128'


### PR DESCRIPTION
This set the header color to the same color Visual Studio Code is using.
I tried with several other settings but finally went the lasy route and
picked the established color. Also tried Wikitext color but I prefer
this color.

I'm still experimenting with the other colors but I suggest to already
start using this new header color