### PR TITLE
Dark Theme - Using #cccccc for normal text

### DIFF
--- a/asciidoctor-editor-plugin/css/dark.css
+++ b/asciidoctor-editor-plugin/css/dark.css
@@ -4,7 +4,7 @@ IEclipsePreferences#de-jcup-asciidoctoreditor:de-jcup-asciidoctoreditor { /* pse
 		'colorTextItalic=88,98,98'
 		'colorTextBold=85,255,255'
 		'colorTextBlocks=49,98,98'
-		'colorNormalText=192,192,192'
+		'colorNormalText=204,204,204'
 		'colorHeadlines=86,156,214'
 		'colorComments=63,127,95',
 		'colorIncludeKeywords=128,128,0'


### PR DESCRIPTION
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=531775 in which
platform switch to this color

Related to #81

Signed-off-by: Lars Vogel <Lars.Vogel@vogella.com>