### PR TITLE
Support .asciidoc as fileending (#105)

### DIFF
--- a/asciidoctor-editor-plugin/src/main/java/de/jcup/asciidoctoreditor/provider/AsciiDoctorBaseDirectoryProvider.java
+++ b/asciidoctor-editor-plugin/src/main/java/de/jcup/asciidoctoreditor/provider/AsciiDoctorBaseDirectoryProvider.java
@@ -83,9 +83,6 @@ public class AsciiDoctorBaseDirectoryProvider {
 			if (file == null || !file.isFile()) {
 				return false;
 			}
-//			if (!file.getName().endsWith(".adoc")) {
-//				return false;
-//			}
 			if(!hasValidFileEnding(file)) {
 				return false;
 			}

--- a/asciidoctor-editor-plugin/src/main/java/de/jcup/asciidoctoreditor/provider/AsciiDoctorBaseDirectoryProvider.java
+++ b/asciidoctor-editor-plugin/src/main/java/de/jcup/asciidoctoreditor/provider/AsciiDoctorBaseDirectoryProvider.java
@@ -77,15 +77,31 @@ public class AsciiDoctorBaseDirectoryProvider {
 
 	private static class ADocFilter implements FileFilter {
 
+		static final String[] validFileEndings = new String[] {".adoc", ".asciidoc"};
 		@Override
 		public boolean accept(File file) {
 			if (file == null || !file.isFile()) {
 				return false;
 			}
-			if (!file.getName().endsWith(".adoc")) {
+//			if (!file.getName().endsWith(".adoc")) {
+//				return false;
+//			}
+			if(!hasValidFileEnding(file)) {
 				return false;
 			}
 			return true;
+		}
+		
+		
+		private boolean hasValidFileEnding(File file) {
+			String fileName = file.getName();
+			for (String validFileEnding : validFileEndings) {
+				if (fileName.endsWith(validFileEnding)) {
+					return true;
+				}
+			}
+			
+			return false;
 		}
 
 	}


### PR DESCRIPTION
Hi,

i've added .asciidoc support into `AsciiDoctorBaseDirectoryProvider.java`.
It seems, that you already fixed the plugin.xml?

- [x]  upgrade AsciiDoctorBaseDirectoryProvider to support those files too
- [ ]   update filextension_asciidoc at marketplace
- [x]   update plugin.xml to provide .asciidoc as well

what has to be done for "update filextension_asciidoc at marketplace"

kind regards