### PR TITLE
[#142] Option for not copying images on save

### DIFF
--- a/asciidoctor-editor-plugin/src/main/java-eclipse/de/jcup/asciidoctoreditor/AsciiDoctorWrapper.java
+++ b/asciidoctor-editor-plugin/src/main/java-eclipse/de/jcup/asciidoctoreditor/AsciiDoctorWrapper.java
@@ -84,6 +84,7 @@ public class AsciiDoctorWrapper {
 
     private void init(AsciiDoctorProviderContext context) {
         context.setUseInstalled(AsciiDoctorEditorPreferences.getInstance().isUsingInstalledAsciidoctor());
+        context.setCopyImages(AsciiDoctorEditorPreferences.getInstance().isCopyImagesForPreview());
         context.setOutputFolder(getTempFolder());
     }
 

--- a/asciidoctor-editor-plugin/src/main/java-eclipse/de/jcup/asciidoctoreditor/preferences/AsciiDoctorEditorPreferenceConstants.java
+++ b/asciidoctor-editor-plugin/src/main/java-eclipse/de/jcup/asciidoctoreditor/preferences/AsciiDoctorEditorPreferenceConstants.java
@@ -29,9 +29,10 @@ public enum AsciiDoctorEditorPreferenceConstants implements PreferenceIdentifiab
 	P_EDITOR_MATCHING_BRACKETS_COLOR("matchingBracketsColor"),
 	P_EDITOR_AUTO_CREATE_END_BRACKETSY("autoCreateEndBrackets"),
 	
+	P_COPY_IMAGES_FOR_PREVIEW("copyImagesForPreview"),
 	P_LINK_OUTLINE_WITH_EDITOR("linkOutlineWithEditor"),
 	P_LINK_EDITOR_WITH_PREVIEW("linkEditorWithPreview"),
-	
+
 	P_CODE_ASSIST_ADD_KEYWORDS("codeAssistAddsKeyWords"),
 	P_CODE_ASSIST_ADD_SIMPLEWORDS("codeAssistAddsSimpleWords"),
 	

--- a/asciidoctor-editor-plugin/src/main/java-eclipse/de/jcup/asciidoctoreditor/preferences/AsciiDoctorEditorPreferenceInitializer.java
+++ b/asciidoctor-editor-plugin/src/main/java-eclipse/de/jcup/asciidoctoreditor/preferences/AsciiDoctorEditorPreferenceInitializer.java
@@ -41,6 +41,7 @@ public class AsciiDoctorEditorPreferenceInitializer extends AbstractPreferenceIn
 		store.setDefault(P_LINK_OUTLINE_WITH_EDITOR.getId(), true);
 
 		/* Preview*/
+		store.setDefault(P_COPY_IMAGES_FOR_PREVIEW.getId(), true);
 		store.setDefault(P_LINK_EDITOR_WITH_PREVIEW.getId(), true);
 
 		/* ++++++++++++ */

--- a/asciidoctor-editor-plugin/src/main/java-eclipse/de/jcup/asciidoctoreditor/preferences/AsciiDoctorEditorPreferencePage.java
+++ b/asciidoctor-editor-plugin/src/main/java-eclipse/de/jcup/asciidoctoreditor/preferences/AsciiDoctorEditorPreferencePage.java
@@ -199,6 +199,14 @@ public class AsciiDoctorEditorPreferencePage extends FieldEditorPreferencePage i
 		addField(tocLevels);
 
 		devNull = new Composite(uiComposite, SWT.NONE);
+		BooleanFieldEditor copyImagesEnabled = new BooleanFieldEditor(P_COPY_IMAGES_FOR_PREVIEW.getId(),
+				"Copy images for preview", devNull);
+		copyImagesEnabled.getDescriptionControl(devNull)
+				.setToolTipText("When enabled images are copied to a temporary folder and used for preview.\n"
+						+ "This does not work for images with a relative path.");
+		addField(copyImagesEnabled);
+
+		devNull = new Composite(uiComposite, SWT.NONE);
 		BooleanFieldEditor linkEditorWithPreviewEnabled = new BooleanFieldEditor(P_LINK_EDITOR_WITH_PREVIEW.getId(),
 				"Link editor with internal preview", devNull);
 		linkEditorWithPreviewEnabled.getDescriptionControl(devNull)

--- a/asciidoctor-editor-plugin/src/main/java-eclipse/de/jcup/asciidoctoreditor/preferences/AsciiDoctorEditorPreferences.java
+++ b/asciidoctor-editor-plugin/src/main/java-eclipse/de/jcup/asciidoctoreditor/preferences/AsciiDoctorEditorPreferences.java
@@ -226,5 +226,7 @@ public class AsciiDoctorEditorPreferences {
 		return getStringPreference(AsciiDoctorEditorPreferenceConstants.P_PATH_TO_INSTALLED_ASCIICDOCTOR);
 	}
 
-
+	public boolean isCopyImagesForPreview() {
+		return getBooleanPreference(P_COPY_IMAGES_FOR_PREVIEW);
+	}
 }

--- a/asciidoctor-editor-plugin/src/main/java/de/jcup/asciidoctoreditor/provider/AsciiDoctorOptionsProvider.java
+++ b/asciidoctor-editor-plugin/src/main/java/de/jcup/asciidoctoreditor/provider/AsciiDoctorOptionsProvider.java
@@ -37,14 +37,12 @@ public class AsciiDoctorOptionsProvider extends AbstractAsciiDoctorProvider {
 		if (outputFolder==null){
 			throw new IllegalStateException("output folder not defined");
 		}
-		getContext().getImageProvider().ensureImages();
 		
 		AttributesBuilder attrBuilder = AttributesBuilder.
 				attributes().
 					showTitle(true).
 					sourceHighlighter("coderay").
 					attribute("eclipse-editor-basedir",getContext().getBaseDir().getAbsolutePath()).
-					attribute("imagesoutdir", createAbsolutePath(getContext().targetImagesDir.toPath())).
 				    attribute("icons", "font").
 					attribute("source-highlighter","coderay").
 					attribute("coderay-css", "style").
@@ -71,7 +69,13 @@ public class AsciiDoctorOptionsProvider extends AbstractAsciiDoctorProvider {
                 attrBuilder.attribute("toclevels", "" + getContext().tocLevels);
             }
         }
-        attrBuilder.imagesDir(getContext().targetImagesDir.getAbsolutePath());
+        if (getContext().isCopyImages()) {
+    		getContext().getImageProvider().ensureImages();
+    		attrBuilder.attribute("imagesoutdir", createAbsolutePath(getContext().targetImagesDir.toPath()));
+    		attrBuilder.imagesDir(getContext().targetImagesDir.getAbsolutePath());
+        } else {
+            attrBuilder.imagesDir(getContext().getBaseDir().getAbsolutePath());
+        }
 
         attrs = attrBuilder.get();
         attrs.setAttribute("outdir", createAbsolutePath(outputFolder));

--- a/asciidoctor-editor-plugin/src/main/java/de/jcup/asciidoctoreditor/provider/AsciiDoctorProviderContext.java
+++ b/asciidoctor-editor-plugin/src/main/java/de/jcup/asciidoctoreditor/provider/AsciiDoctorProviderContext.java
@@ -42,6 +42,7 @@ public class AsciiDoctorProviderContext {
     int tocLevels;
     private boolean useInstalled;
     private File fileToRender;
+    private boolean copyImages;
 
     public AsciiDoctorProviderContext(AsciiDoctorInstanceProvider provider, LogAdapter logAdapter) {
         if (logAdapter == null) {
@@ -166,6 +167,14 @@ public class AsciiDoctorProviderContext {
     public File getFileToRender() {
         return fileToRender;
     }
+    
+    public void setCopyImages(boolean copyImages) {
+		this.copyImages = copyImages;
+	}
+    
+    public boolean isCopyImages() {
+		return copyImages;
+	}
 
     private Set<AbstractAsciiDoctorProvider> providers = new LinkedHashSet<>();
     


### PR DESCRIPTION
We have problems with rendering images in our asciidoc files as we're using relative paths for our images which are not considered while copying the images for preview (related to issue #142).
Also it is not clear to me why images are copied in the first place, so I've created an option to use the images in their original location, hence this pull request.