### PR TITLE
fix(proposals) only use linux style path for proposals

### DIFF
--- a/asciidoctor-editor-plugin/src/main/java/de/jcup/asciidoctoreditor/script/AsciiDoctorFileReferenceValidator.java
+++ b/asciidoctor-editor-plugin/src/main/java/de/jcup/asciidoctoreditor/script/AsciiDoctorFileReferenceValidator.java
@@ -16,6 +16,7 @@
 package de.jcup.asciidoctoreditor.script;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.Collection;
 
 public class AsciiDoctorFileReferenceValidator {
@@ -42,7 +43,7 @@ public class AsciiDoctorFileReferenceValidator {
         }
         for (AsciiDoctorFileReference reference: references) {
             String target = reference.getFilePath();
-            File file = new File(folder.getAbsolutePath()+File.separatorChar+target);
+            File file = folder.toPath().resolve(Paths.get(target)).toFile();
             String problem = null;
             if (! file.exists()) {
                 problem = ".. references not existing file:"+file.getAbsolutePath();

--- a/asciidoctor-editor-plugin/src/test/java/de/jcup/asciidoctoreditor/TestResourcesLoader.java
+++ b/asciidoctor-editor-plugin/src/test/java/de/jcup/asciidoctoreditor/TestResourcesLoader.java
@@ -47,8 +47,7 @@ public class TestResourcesLoader {
 
     public static File assertTestFile(String relativePathInTestResources) {
         try{
-            String path = testResourceRootFolder.getCanonicalFile().getAbsolutePath()+"/"+relativePathInTestResources;
-            File file = new File(path);
+            File file = testResourceRootFolder.getCanonicalFile().toPath().resolve(relativePathInTestResources).toFile();
             file = file.getAbsoluteFile();
             if (!file.exists()){
                 throw new IllegalArgumentException("Test case corrupt! Test resource file does not exist:"+file);


### PR DESCRIPTION
Insure better interoperability between linux and windows as linux path
style are properly interpreted by asciidoc in the backend on windows, whereas
windows path style may not be on a linux backend.

In addition, it fixes the proposals tests on windows.

I have added a fix for :imgaesdir: support in the  image file reference validation