### PR TITLE
enforce UTF-8 encoding of eclipse projects

### DIFF
--- a/asciidoctor-converter-feature/.settings/org.eclipse.core.resources.prefs
+++ b/asciidoctor-converter-feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/asciidoctor-converter-plugin/.settings/org.eclipse.core.resources.prefs
+++ b/asciidoctor-converter-plugin/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/asciidoctor-editor-css/.settings/org.eclipse.core.resources.prefs
+++ b/asciidoctor-editor-css/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/asciidoctor-editor-feature/.settings/org.eclipse.core.resources.prefs
+++ b/asciidoctor-editor-feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/asciidoctor-editor-libs/.settings/org.eclipse.core.resources.prefs
+++ b/asciidoctor-editor-libs/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/asciidoctor-editor-plugin/.settings/org.eclipse.core.resources.prefs
+++ b/asciidoctor-editor-plugin/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/asciidoctor-editor-updatesite/.settings/org.eclipse.core.resources.prefs
+++ b/asciidoctor-editor-updatesite/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
By default, the encoding of Eclipse projects is that of the workspace.
And that in turn depends on the OS. Therefore importing the repository
on Windows leads to most projects being encoded as codepage 1252, not
UTF-8 (and German umlauts are garbled then).

Fix this by storing the encoding preference in each project. That way it
does not matter how the workspace encoding is configured.