### PR TITLE
make compatible with Eclipse Photon

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ For more information
 - call `gradlew installLibraries` - this will install current asp dependencies etc. (so its not inside git)
 - call `gradlew eclipse`
 - After this is done open your eclipse and import *ALL* existing eclipse projects from `eclipse-asciidoctor-editor` into your workspace
+- Open `asciidoctor-editor.target` and click *Set as Active Target Platform*. That way the code is compiled against a fixed version of Eclipse instead of against the current Eclipse IDE.
 ### Build
 - Gradle parts are only used for automated testing
 - To build the editor plugin, please open "asciidoctor-editor-updatesite/site.xml"

--- a/asciidoctor-editor-plugin/META-INF/MANIFEST.MF
+++ b/asciidoctor-editor-plugin/META-INF/MANIFEST.MF
@@ -19,9 +19,9 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.console,
  de.jcup.asciidoctoreditor.libs,
  de.jcup.asciidoctoreditor.css,
- org.eclipse.search;bundle-version="3.11.400",
+ org.eclipse.search;bundle-version="3.11.200",
  org.eclipse.ltk.ui.refactoring,
- org.eclipse.ltk.core.refactoring;bundle-version="3.9.200"
+ org.eclipse.ltk.core.refactoring;bundle-version="3.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.ui,

--- a/asciidoctor-editor-target/.settings/org.eclipse.core.resources.prefs
+++ b/asciidoctor-editor-target/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/asciidoctor-editor-target/asciidoctor-editor.target
+++ b/asciidoctor-editor-target/asciidoctor-editor.target
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="asciidoctor-editor">
+	<locations>
+		<location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
+			<unit id="org.eclipse.sdk.ide" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/releases/photon/201806271001/"/>
+		</location>
+	</locations>
+</target>


### PR DESCRIPTION
The plugin does not use an explicit target platform, therefore it
compiles against the current IDE. That in turn makes adding versioned
dependencies a nightmare, since the version numbers depend on the IDE
version of the current developer. That's why the plugin is currently not
downwards compatible to older eclipse versions (some PR introduced high
version number dependencies).

Add an explicit target platform based on Eclipse photon. Describe in the
README how to use it. Fix the bad version numbers in the manifest to
become compatible with Eclipse Photon.