### PR TITLE
fix(preview): Image preview

### DIFF
--- a/asciidoctor-editor-plugin/src/main/java-eclipse/de/jcup/asciidoctoreditor/preview/AsciidocEditorPreviewBuildRunnnable.java
+++ b/asciidoctor-editor-plugin/src/main/java-eclipse/de/jcup/asciidoctoreditor/preview/AsciidocEditorPreviewBuildRunnnable.java
@@ -19,6 +19,7 @@ import static de.jcup.asciidoctoreditor.util.EclipseUtil.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URLDecoder;
 import java.nio.file.Path;
 import java.util.Set;
 
@@ -208,7 +209,9 @@ class AsciidocEditorPreviewBuildRunnnable implements ICoreRunnable {
                 /* we do not replace URIs - e.g. https://example.com/...*/
                 continue;
             }
-            File file = new File(path);
+            
+            // file path might contains spaces or special characters that are URL encoded
+            File file = new File(URLDecoder.decode(path, "UTF-8"));
             if (file.exists()) {
                 /* keep as is */
                 continue;


### PR DESCRIPTION
When the image path contains a character that requires to be URL encoded
in the HTML, the preview is broken.

This fix consist of URL decoding those path before testing if file
exists.

Closes https://github.com/de-jcup/eclipse-asciidoctor-editor/issues/392

Signed-off-by: Romain Bioteau <romain.bioteau@bonitasoft.com>