### PR TITLE
fix(edge): Use edge renderer

### DIFF
--- a/asciidoctor-editor-plugin/src/main/java-eclipse/de/jcup/asciidoctoreditor/preview/BrowserAccess.java
+++ b/asciidoctor-editor-plugin/src/main/java-eclipse/de/jcup/asciidoctoreditor/preview/BrowserAccess.java
@@ -93,7 +93,10 @@ public class BrowserAccess {
     public Browser ensureBrowser(BrowserContentInitializer initializer) {
         synchronized (monitor) {
             if (browser == null) {
-                browser = new Browser(sashForm, SWT.CENTER);
+            	// Use edge renderer for SWT browser if available
+            	String edgeVersion = System.getProperty("org.eclipse.swt.browser.EdgeVersion");
+            	int browserStyle = edgeVersion != null && !edgeVersion.isEmpty() ? SWT.CENTER | SWT.EDGE : SWT.CENTER; 
+            	browser = new Browser(sashForm, browserStyle);
                 /*
                  * FIXME ATR, 26.04.2018: the initializer parts are no longer used - check if
                  * this could be removed


### PR DESCRIPTION
When using the internal preview on windows, the default renderer is
based on IE. Since a few eclipse version the SWT Browser supports Edge
on windows.

This PR suggest enabling the Edge renderer when available.
Using the modern renderer fix issues on windows where the svg images are
not display in the internal browser.

Closes https://github.com/de-jcup/eclipse-asciidoctor-editor/issues/394