### PR TITLE
Added context menu to outline view

### DIFF
--- a/asciidoctor-editor-plugin/src/main/java-eclipse/de/jcup/asciidoctoreditor/outline/AsciiDoctorContentOutlinePage.java
+++ b/asciidoctor-editor-plugin/src/main/java-eclipse/de/jcup/asciidoctoreditor/outline/AsciiDoctorContentOutlinePage.java
@@ -18,6 +18,7 @@ package de.jcup.asciidoctoreditor.outline;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.IToolBarManager;
+import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.DelegatingStyledCellLabelProvider;
@@ -30,7 +31,9 @@ import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Menu;
 import org.eclipse.ui.IActionBars;
+import org.eclipse.ui.IWorkbenchActionConstants;
 import org.eclipse.ui.IWorkbenchCommandConstants;
 import org.eclipse.ui.views.contentoutline.ContentOutlinePage;
 
@@ -48,6 +51,9 @@ public class AsciiDoctorContentOutlinePage extends ContentOutlinePage implements
     private static final ImageDescriptor IMG_DESC_NOT_LINKED = createOutlineImageDescriptor("sync_broken.png");
     private static final ImageDescriptor IMG_DESC_EXPAND_ALL = createOutlineImageDescriptor("expandall.png");
     private static final ImageDescriptor IMG_DESC_COLLAPSE_ALL = createOutlineImageDescriptor("collapseall.png");
+    
+    private static final String MENU_ID = "de.jcup.asciidoctoreditor.outline";
+	private static final String CONTEXT_MENU_ID = "AsciiDoctorOutlinePageContextMenu";
 
     private AsciiDoctorEditorTreeContentProvider contentProvider;
     private Object input;
@@ -99,6 +105,8 @@ public class AsciiDoctorContentOutlinePage extends ContentOutlinePage implements
 
         viewMenuManager.add(new Separator("treeGroup")); //$NON-NLS-1$
         viewMenuManager.add(toggleLinkingAction);
+        
+        configureContextMenu();
 
         /*
          * when no input is set on init state - let the editor rebuild outline (async)
@@ -109,6 +117,16 @@ public class AsciiDoctorContentOutlinePage extends ContentOutlinePage implements
 
     }
 
+    private void configureContextMenu() {
+		MenuManager menuManager = new MenuManager(CONTEXT_MENU_ID, CONTEXT_MENU_ID);
+		menuManager.add(new Separator(IWorkbenchActionConstants.MB_ADDITIONS));
+		menuManager.setRemoveAllWhenShown(true);
+		
+		Menu contextMenu = menuManager.createContextMenu(getTreeViewer().getTree());
+		getTreeViewer().getTree().setMenu(contextMenu);
+		getSite().registerContextMenu(MENU_ID, menuManager, getTreeViewer());
+	}
+    
     @Override
     public void doubleClick(DoubleClickEvent event) {
         if (editor == null) {


### PR DESCRIPTION
The outline view of the AsciiDoctor Editor currently has no context menu. This also means that context menu contributions from other plug-ins are not visible in the outline view. This limits interoperability with other plug-ins that might be installed in the same Eclipse installation.

A concrete use case for this functionality is provided by [Eclipse Capra](https://eclipse.org/capra), a traceability management tool. It hooks into context menus for viewers and editors for supported artifacts to allow these artifacts to be added to a traceability link (see screenshot). Without the context menu enabled in the AsciiDoctor Editor, this functionality would not be available.

![image](https://user-images.githubusercontent.com/13851848/179218775-f2b79fa4-f4ec-435a-885a-831f8df633ff.png)
