### PR TITLE
Fix #429: Expose editor API for programmatic use

### DIFF
--- a/asciidoctor-editor-plugin/META-INF/MANIFEST.MF
+++ b/asciidoctor-editor-plugin/META-INF/MANIFEST.MF
@@ -27,6 +27,8 @@ Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.ui,
  org.eclipse.ui.texteditor.spelling,
  org.eclipse.ui.texteditor.templates
+Export-Package: de.jcup.asciidoctoreditor,
+ de.jcup.asciidoctoreditor.outline
 Bundle-ClassPath: .,
  lib/de-jcup-eclipse-commons.jar,
  lib/commons-io-2.6.jar,


### PR DESCRIPTION
In order to programmatically access the main Eclipse Asciidoctor Editor
components, they need to be exposed as API. This commit adds the two
packages de.jcup.asciidoctoreditor and
de.jcup.asciidoctoreditor.outline, thus allowing access to the main
editor view as well as the outline page and its model.